### PR TITLE
Bump version for for 24.2 SPS release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unity-sps-ogc-processes-api"
-version = "0.0.1-beta.1"
+version = "1.0.0"
 authors = [
     { name = "Drew Meyers", email = "drew.meyers@jpl.nasa.gov" },
 ]


### PR DESCRIPTION
## Purpose

- Merge changes from "develop" into "main" in preparation for SPS 24.2 release

## Issues

- See SPS 24.2 project board: https://github.com/orgs/unity-sds/projects/3/views/19

## Testing

- Unit tests succeeding
- Static analysis succeeding
